### PR TITLE
New option to allow skip empty translations from destination JSON

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,10 @@ module.exports = function(options) {
             } else {
                 parseOptions = {comment: '#'};
             }
+            var skipEmptyTranslations = false;
+            if (options && options.skipEmptyTranslations) {
+                skipEmptyTranslations = true;
+            }
 
             parse(csvText, parseOptions, function(err, output) {
                 if (err) {
@@ -54,7 +58,9 @@ module.exports = function(options) {
                                     console.warn('gulp-csv-angular-translate: FOUND DUPLICATE TRANSLATION-KEY ['+output[row][0]+']');
                                     duplicateErrorPrinted = true;
                                 }
-                                files[column - 1].fileContent[output[row][0]] = output[row][column];
+                                if (output[row][column] || !skipEmptyTranslations) {
+                                    files[column - 1].fileContent[output[row][0]] = output[row][column];
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
We use this module to convert csv translations file, but different languages are translate by different people, so sometimes not all translations are available for every row - actually there is saved an empty string as a translation in JSON file and empty string is displayed in Angular application. Could you please add this extra setting to skip this not ready translations?